### PR TITLE
Add support for home directory if prefix 'file:' is given ('file:~/...')

### DIFF
--- a/pathfinder/pom.xml
+++ b/pathfinder/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pathfinder-parent</artifactId>
     <groupId>com.github.dbmdz.pathfinder</groupId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pathfinder/src/main/java/com/github/dbmdz/pathfinder/Pathfinder.java
+++ b/pathfinder/src/main/java/com/github/dbmdz/pathfinder/Pathfinder.java
@@ -46,7 +46,7 @@ public class Pathfinder {
    * @see java.util.regex.Pattern
    */
   public Pathfinder addPattern(String pattern, String template) {
-    if (template.startsWith("~/")) {
+    if (template.startsWith("~/") || template.startsWith("file:~/")) {
       template = template.replaceFirst("~/", userHomeDirectory);
     }
     pathSpecs.add(new PathSpec(pattern, template, fileSystem));

--- a/pathfinder/src/test/java/com/github/dbmdz/pathfinder/PathfinderTest.java
+++ b/pathfinder/src/test/java/com/github/dbmdz/pathfinder/PathfinderTest.java
@@ -41,6 +41,11 @@ public class PathfinderTest {
     Optional<Path> actual = pathfinder.find("123");
     Path expected = fs.path("/home/tester/subdir1/subdir2/filename.xml");
     assertThat(actual).contains(expected);
+
+    pathfinder.addPattern("456", "file:~/subdir1/subdir2/filename.xml");
+    actual = pathfinder.find("456");
+    expected = fs.path("file:/home/tester/subdir1/subdir2/filename.xml");
+    assertThat(actual).contains(expected);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.github.dbmdz.pathfinder</groupId>
   <artifactId>pathfinder-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
   <modules>
     <module>pathfinder</module>
     <module>spring-boot-pathfinder</module>

--- a/spring-boot-pathfinder/pom.xml
+++ b/spring-boot-pathfinder/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>pathfinder-parent</artifactId>
     <groupId>com.github.dbmdz.pathfinder</groupId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
prefix "file:" is needed in case I am using Paths with Spring ResourceLoader, otherwise it is interpreted as servletcontextpath